### PR TITLE
set chnnel_id for Slack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-slash-command",
   "description": "It redirects slash command of Slack and Mattermost to hubot message.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "eichisanden",
   "license": "MIT",
   "keywords": "hubot, mattermost, slack, slash command",

--- a/src/hubot-slash-command.js
+++ b/src/hubot-slash-command.js
@@ -42,7 +42,12 @@ module.exports = (robot) => {
 
     const user = robot.brain.userForId(req.body.user_id);
     user.name = req.body.user_name;
-    user.room = req.body.channel_name;
+    // Set channel_id for private channel of Slack
+    if (req.get('user-agent').match(/slack/i)) {
+      user.room = req.body.channel_id;
+    } else {
+      user.room = req.body.channel_name;
+    }
     robot.receive(new TextMessage(user, applyTemplate(receiveMessage, dict)));
 
     const msg = {};


### PR DESCRIPTION
Can't response message to private channel of Slack.
Since all private channels have the same channel_name `privategroup`.
When accessing from Slack, `channel_id` is used instead of `channel_name`.